### PR TITLE
Add sort and multi-sort URL sync

### DIFF
--- a/src/core/ag-grid-url-sync.ts
+++ b/src/core/ag-grid-url-sync.ts
@@ -4,12 +4,18 @@ import type {
   FilterState,
   InternalConfig,
   SerializationFormat,
-  SerializationMode
+  SerializationMode,
+  SortState
 } from './types.js'
 import { DEFAULT_CONFIG } from './validation.js'
-import { parseUrlFilters } from './url-parser.js'
+import { parseUrlFilters, parseSortState } from './url-parser.js'
 import { generateUrl } from './url-generator.js'
-import { getFilterModel, applyFilterModel } from './grid-integration.js'
+import {
+  getFilterModel,
+  applyFilterModel,
+  getSortState,
+  applySortState
+} from './grid-integration.js'
 import { serializeGrouped } from './serialization/grouped.js'
 
 /**
@@ -39,7 +45,8 @@ export class AGGridUrlSync {
   generateUrl(baseUrl?: string): string {
     const filterState = getFilterModel(this.config)
     const url = baseUrl ?? window.location.href
-    return generateUrl(url, filterState, this.config)
+    const sortState = getSortState(this.config)
+    return generateUrl(url, filterState, this.config, sortState)
   }
 
   /**
@@ -60,6 +67,9 @@ export class AGGridUrlSync {
     const urlToParse = url ?? window.location.href
     const filterState = parseUrlFilters(urlToParse, this.config)
     this.applyFilters(filterState)
+
+    const sortState = parseSortState(urlToParse, this.config)
+    applySortState(sortState, this.config)
   }
 
   /**
@@ -75,6 +85,24 @@ export class AGGridUrlSync {
    */
   clearFilters(): void {
     this.applyFilters({})
+  }
+
+  getSortState(): SortState {
+    return getSortState(this.config)
+  }
+
+  applySortFromUrl(url?: string): void {
+    const urlToParse = url ?? window.location.href
+    const sortState = parseSortState(urlToParse, this.config)
+    applySortState(sortState, this.config)
+  }
+
+  applySortState(sortState: SortState): void {
+    applySortState(sortState, this.config)
+  }
+
+  clearSortState(): void {
+    applySortState([], this.config)
   }
 
   /**

--- a/src/core/grid-integration.ts
+++ b/src/core/grid-integration.ts
@@ -7,7 +7,9 @@ import type {
   DateFilterOperation,
   FilterOperation,
   AGGridFilter,
-  RawAGGridFilter
+  RawAGGridFilter,
+  SortState,
+  ColumnSortState
 } from './types.js'
 import type { ISimpleFilterModelType } from 'ag-grid-community'
 import {
@@ -375,6 +377,64 @@ export function applyFilterModel(
 
     // Apply the filter model to AG Grid
     config.gridApi.setFilterModel(model)
+  } catch (error) {
+    if (config.onParseError) {
+      config.onParseError(error as Error)
+    }
+  }
+}
+
+export function getSortState(config: InternalConfig): SortState {
+  try {
+    const sortModel = config.gridApi.getColumnState()
+
+    if (!sortModel || !Array.isArray(sortModel)) {
+      return []
+    }
+
+    const sortState: SortState = []
+
+    for (const colState of sortModel) {
+      if (colState.sort) {
+        sortState.push({
+          colId: colState.colId,
+          sort: colState.sort as 'asc' | 'desc',
+          index: sortState.length
+        })
+      }
+    }
+
+    return sortState
+  } catch (error) {
+    if (config.onParseError) {
+      config.onParseError(error as Error)
+    }
+    return []
+  }
+}
+
+export function applySortState(
+  sortState: SortState,
+  config: InternalConfig
+): void {
+  try {
+    if (!sortState || sortState.length === 0) {
+      config.gridApi.applyColumnState({
+        state: [],
+        defaultState: { sort: null }
+      })
+      return
+    }
+
+    const columnState = sortState.map((colSort: ColumnSortState) => ({
+      colId: colSort.colId,
+      sort: colSort.sort
+    }))
+
+    config.gridApi.applyColumnState({
+      state: columnState,
+      defaultState: { sort: null }
+    })
   } catch (error) {
     if (config.onParseError) {
       config.onParseError(error as Error)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,13 +6,26 @@ export * from './types.js'
 export { validateFilterValue, DEFAULT_CONFIG } from './validation.js'
 
 // URL parsing utilities
-export { parseUrlFilters, parseFilterParam } from './url-parser.js'
+export {
+  parseUrlFilters,
+  parseFilterParam,
+  parseSortState
+} from './url-parser.js'
 
 // URL generation utilities
-export { serializeFilters, generateUrl } from './url-generator.js'
+export {
+  serializeFilters,
+  serializeSortState,
+  generateUrl
+} from './url-generator.js'
 
 // AG Grid integration utilities
-export { getFilterModel, applyFilterModel } from './grid-integration.js'
+export {
+  getFilterModel,
+  applyFilterModel,
+  getSortState,
+  applySortState
+} from './grid-integration.js'
 
 // Grouped serialization utilities
 export * from './serialization/index.js'

--- a/src/core/sort-state.test.ts
+++ b/src/core/sort-state.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AGGridUrlSync } from './ag-grid-url-sync.js'
+import { parseSortState } from './url-parser.js'
+import { serializeSortState } from './url-generator.js'
+import { getSortState, applySortState } from './grid-integration.js'
+import type { GridApi } from 'ag-grid-community'
+import type { InternalConfig, SortState } from './types.js'
+import { DEFAULT_CONFIG } from './validation.js'
+
+describe('Sort State Synchronization', () => {
+  const mockGridApi = {
+    getColumnState: vi.fn(),
+    applyColumnState: vi.fn()
+  } as unknown as GridApi
+
+  const config: InternalConfig = {
+    gridApi: mockGridApi,
+    paramPrefix: 'f_',
+    maxValueLength: 200,
+    onParseError: vi.fn(),
+    serialization: 'individual',
+    format: 'querystring',
+    groupedParam: 'grid_filters',
+    sortPrefix: 's_'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getSortState', () => {
+    it('should return empty array when no columns are sorted', () => {
+      mockGridApi.getColumnState = vi.fn().mockReturnValue([])
+
+      const result = getSortState(config)
+
+      expect(result).toEqual([])
+    })
+
+    it('should return single sort state for one sorted column', () => {
+      mockGridApi.getColumnState = vi
+        .fn()
+        .mockReturnValue([{ colId: 'name', sort: 'asc' }])
+
+      const result = getSortState(config)
+
+      expect(result).toEqual([{ colId: 'name', sort: 'asc', index: 0 }])
+    })
+
+    it('should return sort state for multiple sorted columns', () => {
+      mockGridApi.getColumnState = vi.fn().mockReturnValue([
+        { colId: 'name', sort: 'asc' },
+        { colId: 'salary', sort: 'desc' }
+      ])
+
+      const result = getSortState(config)
+
+      expect(result).toEqual([
+        { colId: 'name', sort: 'asc', index: 0 },
+        { colId: 'salary', sort: 'desc', index: 1 }
+      ])
+    })
+  })
+
+  describe('applySortState', () => {
+    it('should apply single column sort', () => {
+      const sortState: SortState = [{ colId: 'name', sort: 'asc' }]
+
+      applySortState(sortState, config)
+
+      expect(mockGridApi.applyColumnState).toHaveBeenCalledWith({
+        state: [{ colId: 'name', sort: 'asc' }],
+        defaultState: { sort: null }
+      })
+    })
+
+    it('should apply multiple column sort', () => {
+      const sortState: SortState = [
+        { colId: 'name', sort: 'asc' },
+        { colId: 'salary', sort: 'desc' }
+      ]
+
+      applySortState(sortState, config)
+
+      expect(mockGridApi.applyColumnState).toHaveBeenCalledWith({
+        state: [
+          { colId: 'name', sort: 'asc' },
+          { colId: 'salary', sort: 'desc' }
+        ],
+        defaultState: { sort: null }
+      })
+    })
+
+    it('should clear all sorts when empty array provided', () => {
+      const sortState: SortState = []
+
+      applySortState(sortState, config)
+
+      expect(mockGridApi.applyColumnState).toHaveBeenCalledWith({
+        state: [],
+        defaultState: { sort: null }
+      })
+    })
+  })
+
+  describe('serializeSortState', () => {
+    it('should serialize single column sort to URL', () => {
+      const sortState: SortState = [{ colId: 'name', sort: 'asc' }]
+
+      const params = serializeSortState(sortState, config)
+
+      expect(params.toString()).toBe('s_name=asc')
+    })
+
+    it('should serialize descending sort', () => {
+      const sortState: SortState = [{ colId: 'salary', sort: 'desc' }]
+
+      const params = serializeSortState(sortState, config)
+
+      expect(params.toString()).toBe('s_salary=desc')
+    })
+
+    it('should serialize multiple column sorts', () => {
+      const sortState: SortState = [
+        { colId: 'name', sort: 'asc' },
+        { colId: 'salary', sort: 'desc' }
+      ]
+
+      const params = serializeSortState(sortState, config)
+
+      expect(params.get('s_name_1')).toBe('asc')
+      expect(params.get('s_salary_2')).toBe('desc')
+    })
+
+    it('should return empty params for empty sort state', () => {
+      const sortState: SortState = []
+
+      const params = serializeSortState(sortState, config)
+
+      expect(params.toString()).toBe('')
+    })
+  })
+
+  describe('parseSortState', () => {
+    it('should parse single column sort from URL', () => {
+      const url = 'https://example.com?s_name=asc'
+
+      const result = parseSortState(url, config)
+
+      expect(result).toEqual([{ colId: 'name', sort: 'asc' }])
+    })
+
+    it('should parse descending sort', () => {
+      const url = 'https://example.com?s_salary=desc'
+
+      const result = parseSortState(url, config)
+
+      expect(result).toEqual([{ colId: 'salary', sort: 'desc' }])
+    })
+
+    it('should parse multiple column sorts from URL', () => {
+      const url = 'https://example.com?s_name_1=asc&s_salary_2=desc'
+
+      const result = parseSortState(url, config)
+
+      expect(result).toEqual([
+        { colId: 'name', sort: 'asc' },
+        { colId: 'salary', sort: 'desc' }
+      ])
+    })
+
+    it('should return empty array when no sort params', () => {
+      const url = 'https://example.com?f_name_contains=john'
+
+      const result = parseSortState(url, config)
+
+      expect(result).toEqual([])
+    })
+
+    it('should ignore invalid sort values', () => {
+      const url = 'https://example.com?s_name=invalid'
+
+      const result = parseSortState(url, config)
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('AGGridUrlSync with sort enabled', () => {
+    it('should include sort state in URL', () => {
+      mockGridApi.getFilterModel = vi.fn().mockReturnValue({})
+      mockGridApi.getColumnState = vi
+        .fn()
+        .mockReturnValue([{ colId: 'name', sort: 'asc' }])
+
+      const urlSync = new AGGridUrlSync(mockGridApi)
+
+      const url = urlSync.generateUrl('https://example.com')
+
+      expect(url).toContain('s_name=asc')
+    })
+
+    it('should apply sort from URL', () => {
+      mockGridApi.setFilterModel = vi.fn()
+      mockGridApi.applyColumnState = vi.fn()
+
+      const urlSync = new AGGridUrlSync(mockGridApi)
+
+      urlSync.applyFromUrl('https://example.com?s_name=asc')
+
+      expect(mockGridApi.applyColumnState).toHaveBeenCalledWith({
+        state: [{ colId: 'name', sort: 'asc' }],
+        defaultState: { sort: null }
+      })
+    })
+
+    it('should provide getSortState method', () => {
+      mockGridApi.getFilterModel = vi.fn().mockReturnValue({})
+      mockGridApi.getColumnState = vi
+        .fn()
+        .mockReturnValue([{ colId: 'name', sort: 'desc' }])
+
+      const urlSync = new AGGridUrlSync(mockGridApi)
+
+      const sortState = urlSync.getSortState()
+
+      expect(sortState).toEqual([{ colId: 'name', sort: 'desc', index: 0 }])
+    })
+
+    it('should provide clearSortState method', () => {
+      mockGridApi.setFilterModel = vi.fn()
+      mockGridApi.applyColumnState = vi.fn()
+
+      const urlSync = new AGGridUrlSync(mockGridApi)
+
+      urlSync.clearSortState()
+
+      expect(mockGridApi.applyColumnState).toHaveBeenCalledWith({
+        state: [],
+        defaultState: { sort: null }
+      })
+    })
+  })
+})

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -76,6 +76,8 @@ export interface AGGridUrlSyncConfig {
    * @default 'querystring'
    */
   format?: SerializationFormat
+
+  sortPrefix?: string
 }
 
 /**
@@ -85,6 +87,16 @@ export interface InternalConfig extends Required<AGGridUrlSyncConfig> {
   /** AG Grid API instance for filter operations */
   gridApi: AGGridApi
 }
+
+export type SortDirection = 'asc' | 'desc' | null
+
+export interface ColumnSortState {
+  colId: string
+  sort: 'asc' | 'desc'
+  index?: number
+}
+
+export type SortState = ColumnSortState[]
 
 // ============================================================================
 // FILTER OPERATION DEFINITIONS

--- a/src/core/url-generator.ts
+++ b/src/core/url-generator.ts
@@ -1,4 +1,9 @@
-import type { FilterState, InternalConfig, ColumnFilter } from './types.js'
+import type {
+  FilterState,
+  InternalConfig,
+  ColumnFilter,
+  SortState
+} from './types.js'
 import { validateFilterValue } from './validation.js'
 import { INTERNAL_TO_URL_OPERATION_MAP } from './types.js'
 import { serializeGrouped } from './serialization/grouped.js'
@@ -142,6 +147,36 @@ export function serializeFilters(
   return params
 }
 
+export function serializeSortState(
+  sortState: SortState,
+  config: InternalConfig
+): URLSearchParams {
+  const params = new URLSearchParams()
+
+  if (!sortState || sortState.length === 0) {
+    return params
+  }
+
+  const prefix = config.sortPrefix || 's_'
+
+  if (sortState.length === 1) {
+    const sort = sortState[0]
+    if (sort) {
+      params.set(`${prefix}${sort.colId}`, sort.sort)
+    }
+  } else {
+    for (let i = 0; i < sortState.length; i++) {
+      const sort = sortState[i]
+      if (sort) {
+        const index = i + 1
+        params.set(`${prefix}${sort.colId}_${index}`, sort.sort)
+      }
+    }
+  }
+
+  return params
+}
+
 /**
  * Helper to extract and preserve non-filter parameters from a URL
  */
@@ -169,17 +204,25 @@ function getPreservedParams(
 export function generateUrl(
   baseUrl: string,
   filterState: FilterState,
-  config: InternalConfig
+  config: InternalConfig,
+  sortState?: SortState
 ): string {
   const url = new URL(baseUrl)
 
   // Handle grouped serialization
   if (config.serialization === 'grouped') {
-    return generateGroupedUrl(baseUrl, filterState, config)
+    return generateGroupedUrl(baseUrl, filterState, config, sortState)
   }
 
   // Handle individual serialization (existing logic)
   const filterParams = serializeFilters(filterState, config)
+
+  if (sortState && sortState.length > 0) {
+    const sortParams = serializeSortState(sortState, config)
+    for (const [key, value] of sortParams.entries()) {
+      filterParams.append(key, value)
+    }
+  }
 
   // Use shared helper to preserve non-filter parameters
   const preservedParams = getPreservedParams(url, config)
@@ -209,7 +252,8 @@ export function generateUrl(
 function generateGroupedUrl(
   baseUrl: string,
   filterState: FilterState,
-  config: InternalConfig
+  config: InternalConfig,
+  sortState?: SortState
 ): string {
   const url = new URL(baseUrl)
 
@@ -226,6 +270,13 @@ function generateGroupedUrl(
   // Add the grouped parameter if there are filters
   if (groupedResult.value) {
     url.searchParams.set(groupedResult.paramName, groupedResult.value)
+  }
+
+  if (sortState && sortState.length > 0) {
+    const sortParams = serializeSortState(sortState, config)
+    for (const [key, value] of sortParams.entries()) {
+      url.searchParams.set(key, value)
+    }
   }
 
   // If no filters, ensure the grouped param is removed

--- a/src/core/url-parser.ts
+++ b/src/core/url-parser.ts
@@ -1,4 +1,9 @@
-import type { FilterState, ColumnFilter, InternalConfig } from './types.js'
+import type {
+  FilterState,
+  ColumnFilter,
+  InternalConfig,
+  SortState
+} from './types.js'
 import { InvalidFilterError, InvalidURLError, OPERATION_MAP } from './types.js'
 import {
   validateFilterValue,
@@ -319,7 +324,7 @@ export function parseUrlFilters(
     }
 
     // First, try to detect grouped serialization
-    const DEFAULT_GROUPED_PARAMS = ['grid_filters', 'filters'];
+    const DEFAULT_GROUPED_PARAMS = ['grid_filters', 'filters']
     const groupedDetection = detectGroupedSerialization(
       urlToProcess,
       [config.groupedParam, ...DEFAULT_GROUPED_PARAMS] // Common parameter names to check
@@ -386,5 +391,67 @@ export function parseUrlFilters(
     throw new InvalidURLError(
       `Failed to parse URL: ${error instanceof Error ? error.message : 'Unknown error'}`
     )
+  }
+}
+
+export function parseSortState(url: string, config: InternalConfig): SortState {
+  try {
+    let urlToProcess = url
+    if (url.startsWith('?')) {
+      urlToProcess = `http://example.com${url}`
+    } else if (!url.includes('://') && !url.startsWith('/')) {
+      urlToProcess = `http://example.com?${url}`
+    }
+
+    const urlObj = new URL(urlToProcess)
+    const sortState: SortState = []
+    const prefix = config.sortPrefix || 's_'
+
+    const sortParams: Array<{
+      colId: string
+      sort: 'asc' | 'desc'
+      index: number
+    }> = []
+
+    for (const [param, value] of urlObj.searchParams.entries()) {
+      if (!param.startsWith(prefix)) continue
+
+      if (value !== 'asc' && value !== 'desc') continue
+
+      const paramWithoutPrefix = param.substring(prefix.length)
+
+      if (paramWithoutPrefix.includes('_')) {
+        const parts = paramWithoutPrefix.split('_')
+        const lastPart = parts[parts.length - 1]
+        if (!lastPart) continue
+        const colId = parts.slice(0, -1).join('_')
+        const index = parseInt(lastPart, 10)
+        if (!isNaN(index)) {
+          sortParams.push({ colId, sort: value, index })
+        }
+      } else {
+        sortParams.push({
+          colId: paramWithoutPrefix,
+          sort: value,
+          index: sortParams.length
+        })
+      }
+    }
+
+    sortParams.sort((a, b) => a.index - b.index)
+
+    for (const param of sortParams) {
+      sortState.push({
+        colId: param.colId,
+        sort: param.sort
+      })
+    }
+
+    return sortState
+  } catch (error) {
+    if (config.onParseError) {
+      config.onParseError(error as Error)
+    }
+    return []
   }
 }

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -23,6 +23,7 @@ export const DEFAULT_CONFIG = {
   serialization: 'individual' as const,
   groupedParam: 'grid_filters',
   format: 'querystring' as const,
+  sortPrefix: 's_',
   onParseError: () => {}
 } as const
 

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -2,7 +2,8 @@ import type {
   AGGridUrlSyncConfig,
   FilterState,
   SerializationFormat,
-  SerializationMode
+  SerializationMode,
+  SortState
 } from '../core/types.js'
 
 /**
@@ -96,4 +97,14 @@ export interface UseAGGridUrlSyncReturn {
    * @returns The current format
    */
   getCurrentFormat: () => SerializationMode
+
+  getSortState: () => SortState
+
+  applySortFromUrl: (url?: string) => void
+
+  applySortState: (sortState: SortState) => void
+
+  clearSortState: () => void
+
+  hasSort: boolean
 }

--- a/src/react/use-ag-grid-url-sync.test.tsx
+++ b/src/react/use-ag-grid-url-sync.test.tsx
@@ -14,7 +14,11 @@ const mockInstance = {
   applyFromUrl: vi.fn(),
   clearFilters: vi.fn(),
   applyFilters: vi.fn(),
-  destroy: vi.fn()
+  destroy: vi.fn(),
+  getSortState: vi.fn(() => []),
+  applySortFromUrl: vi.fn(),
+  applySortState: vi.fn(),
+  clearSortState: vi.fn()
 }
 
 // Mock the core AG Grid URL sync module
@@ -553,6 +557,103 @@ describe('useAGGridUrlSync', () => {
 
       expect(mockGridApi.removeEventListener).toHaveBeenCalledWith(
         'filterChanged',
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('Sort State', () => {
+    test('returns getSortState function', async () => {
+      mockInstance.getSortState = vi.fn(() => [{ colId: 'name', sort: 'asc' }])
+
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.getSortState).toBeDefined()
+      expect(typeof result.current.getSortState).toBe('function')
+    })
+
+    test('returns hasSort as boolean', async () => {
+      mockInstance.getSortState = vi.fn(() => [{ colId: 'name', sort: 'asc' }])
+
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.hasSort).toBeDefined()
+      expect(typeof result.current.hasSort).toBe('boolean')
+    })
+
+    test('hasSort is false when no sort state', async () => {
+      mockInstance.getSortState = vi.fn(() => [])
+
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.hasSort).toBe(false)
+    })
+
+    test('hasSort is true when sort state exists', async () => {
+      mockInstance.getSortState = vi.fn(() => [{ colId: 'name', sort: 'asc' }])
+      mockInstance.generateUrl = vi.fn(() => 'http://example.com?s_name=asc')
+
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.hasSort).toBe(true)
+    })
+
+    test('returns applySortState function', async () => {
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.applySortState).toBeDefined()
+      expect(typeof result.current.applySortState).toBe('function')
+    })
+
+    test('returns clearSortState function', async () => {
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.clearSortState).toBeDefined()
+      expect(typeof result.current.clearSortState).toBe('function')
+    })
+
+    test('returns applySortFromUrl function', async () => {
+      const { result } = renderHook(() =>
+        useAGGridUrlSync(mockGridApi as GridApi)
+      )
+
+      await waitForEffects()
+
+      expect(result.current.applySortFromUrl).toBeDefined()
+      expect(typeof result.current.applySortFromUrl).toBe('function')
+    })
+
+    test('sets up sortChanged listener', async () => {
+      renderHook(() => useAGGridUrlSync(mockGridApi as GridApi))
+
+      await waitForEffects()
+
+      expect(mockGridApi.addEventListener).toHaveBeenCalledWith(
+        'sortChanged',
         expect.any(Function)
       )
     })

--- a/src/react/use-ag-grid-url-sync.ts
+++ b/src/react/use-ag-grid-url-sync.ts
@@ -6,7 +6,8 @@ import { DEFAULT_CONFIG } from '../core/validation.js'
 import type {
   FilterState,
   SerializationFormat,
-  SerializationMode
+  SerializationMode,
+  SortState
 } from '../core/types.js'
 import type {
   UseAGGridUrlSyncOptions,
@@ -35,6 +36,7 @@ export function useAGGridUrlSync(
   const [isReady, setIsReady] = useState(false)
   const [currentUrl, setCurrentUrl] = useState('')
   const [hasFilters, setHasFilters] = useState(false)
+  const [hasSort, setHasSort] = useState(false)
 
   // Refs to track state and prevent memory leaks
   const urlSyncRef = useRef<AGGridUrlSync | null>(null)
@@ -110,6 +112,7 @@ export function useAGGridUrlSync(
     if (!isReady || !urlSyncRef.current || !gridApi) {
       setCurrentUrl('')
       setHasFilters(false)
+      setHasSort(false)
       return
     }
 
@@ -122,6 +125,9 @@ export function useAGGridUrlSync(
         const queryParams = urlSyncRef.current!.getQueryParams()
         const searchParams = new URLSearchParams(queryParams)
         setHasFilters([...searchParams.entries()].length > 0)
+
+        const sortState = urlSyncRef.current!.getSortState()
+        setHasSort(sortState.length > 0)
       } catch (error) {
         handleError(error, 'update-state')
       }
@@ -131,12 +137,16 @@ export function useAGGridUrlSync(
     const onFilterChanged = () => updateState()
     gridApi.addEventListener('filterChanged', onFilterChanged)
 
+    const onSortChanged = () => updateState()
+    gridApi.addEventListener('sortChanged', onSortChanged)
+
     // Initial state update
     updateState()
 
     // Cleanup event listener on unmount or gridApi change
     return () => {
       gridApi.removeEventListener('filterChanged', onFilterChanged)
+      gridApi.removeEventListener('sortChanged', onSortChanged)
     }
   }, [isReady, gridApi, handleError])
 
@@ -230,7 +240,8 @@ export function useAGGridUrlSync(
           serialization:
             coreOptions.serialization ?? DEFAULT_CONFIG.serialization,
           groupedParam: coreOptions.groupedParam ?? DEFAULT_CONFIG.groupedParam,
-          format: coreOptions.format ?? DEFAULT_CONFIG.format
+          format: coreOptions.format ?? DEFAULT_CONFIG.format,
+          sortPrefix: coreOptions.sortPrefix ?? DEFAULT_CONFIG.sortPrefix
         }
         return parseFilters(url, config)
       } catch (error) {
@@ -287,6 +298,67 @@ export function useAGGridUrlSync(
     }
   }, [handleError])
 
+  const getSortState = useCallback((): SortState => {
+    if (!urlSyncRef.current) {
+      return []
+    }
+    try {
+      return urlSyncRef.current.getSortState()
+    } catch (error) {
+      handleError(error, 'get-sort-state')
+      return []
+    }
+  }, [handleError])
+
+  const applySortFromUrl = useCallback(
+    (url?: string): void => {
+      if (!urlSyncRef.current) {
+        const warningMessage =
+          'applySortFromUrl called while the hook is not ready.'
+        coreOptions.onParseError?.(new Error(warningMessage))
+        return
+      }
+      try {
+        urlSyncRef.current.applySortFromUrl(url)
+      } catch (error) {
+        handleError(error, 'apply-sort-from-url')
+        coreOptions.onParseError?.(error as Error)
+      }
+    },
+    [coreOptions, handleError]
+  )
+
+  const applySortState = useCallback(
+    (sortState: SortState): void => {
+      if (!urlSyncRef.current) {
+        const warningMessage =
+          'applySortState called while the hook is not ready.'
+        coreOptions.onParseError?.(new Error(warningMessage))
+        return
+      }
+      try {
+        urlSyncRef.current.applySortState(sortState)
+      } catch (error) {
+        handleError(error, 'apply-sort-state')
+      }
+    },
+    [handleError, coreOptions]
+  )
+
+  const clearSortState = useCallback((): void => {
+    if (!urlSyncRef.current) {
+      const warningMessage =
+        'clearSortState called while the hook is not ready.'
+      coreOptions.onParseError?.(new Error(warningMessage))
+      return
+    }
+    try {
+      urlSyncRef.current.clearSortState()
+    } catch (error) {
+      handleError(error, 'clear-sort-state')
+    }
+  }, [handleError, coreOptions])
+
   // Return the hook API
   return useMemo(
     () => ({
@@ -300,7 +372,12 @@ export function useAGGridUrlSync(
       parseUrlFilters,
       applyFilters,
       getFiltersAsFormat,
-      getCurrentFormat
+      getCurrentFormat,
+      getSortState,
+      applySortFromUrl,
+      applySortState,
+      clearSortState,
+      hasSort
     }),
     [
       shareUrl,
@@ -313,7 +390,12 @@ export function useAGGridUrlSync(
       parseUrlFilters,
       applyFilters,
       getFiltersAsFormat,
-      getCurrentFormat
+      getCurrentFormat,
+      getSortState,
+      applySortFromUrl,
+      applySortState,
+      clearSortState,
+      hasSort
     ]
   )
 }


### PR DESCRIPTION
## Description
Adds sort state to the URL (including multi-column sorting).

Before, shared links kept filters but not sorting, so data could appear in a different order. Now sorting is read from and saved to the URL, so shared views stay consistent.